### PR TITLE
ext4crypt: add missing cflag

### DIFF
--- a/crypto/ext4crypt/Decrypt.cpp
+++ b/crypto/ext4crypt/Decrypt.cpp
@@ -1336,7 +1336,11 @@ bool Decrypt_User(const userid_t user_id, const std::string& Password) {
 		printf("e4crypt_unlock_user_key returned fail\n");
 		return false;
 	}
-	if (!e4crypt_prepare_user_storage(nullptr, user_id, 0, flags)) {
+#ifdef USE_KEYSTORAGE_4
+		if (!e4crypt_prepare_user_storage("", user_id, 0, flags)) {
+#else
+		if (!e4crypt_prepare_user_storage(nullptr, user_id, 0, flags)) {
+#endif
 		printf("failed to e4crypt_prepare_user_storage\n");
 		return false;
 	}


### PR DESCRIPTION
Avoid calling e4crypt_prepare_user_storage with wrong input parameters.

Change-Id: I5c8945370cb642e46f08c65090c0290c15fe0b57
libc: Fatal signal 11 (SIGSEGV), code 1 (SEGV_MAPERR), fault addr 0x0 in tid 632 (recovery), pid 564 (recovery)

# WE DO NOT MERGE PULL REQUESTS SUBMITTED HERE

You will need to submit it through [OmniRom Gerrit](https://gerrit.omnirom.org/#/admin/projects/android_bootable_recovery/)

For changes to device trees, use [TWRP Gerrit](https://gerrit.twrp.me/)

This guide explani how to use [Gerrit code review](https://forum.xda-developers.com/general/xda-university/guide-using-gerrit-code-review-t3720802)